### PR TITLE
Fix totality warnings.

### DIFF
--- a/Text/PrettyPrint/Leijen.idr
+++ b/Text/PrettyPrint/Leijen.idr
@@ -168,8 +168,8 @@ group x         = Union (flatten x) x
         flatten (Nest i x)      = Nest i (flatten x)
         flatten (Line break)    = if break then Empty else Text 1 " "
         flatten (Union x _)     = flatten x
-        flatten (Column f)      = Column (flatten . f)
-        flatten (Nesting f)     = Nesting (flatten . f)
+        flatten (Column f)      = Column (\i => flatten $ f i)
+        flatten (Nesting f)     = Nesting (\i => flatten $ f i)
         flatten other           = other                     --Empty,Char,Text
 
 


### PR DESCRIPTION
Unfortunatly, the function `flatten`, a where clause of `group` is no
longer being reported as total. Point-free style coding /is to blame/.

This commit removes the style to ensure wl-pprint is considered total.

Honestly, I think Idris should still see the function as total when
using point-free style, but I don't know what has changed in Idris for
it to complain.